### PR TITLE
fix(typescript.md): 修正了一个笔误

### DIFF
--- a/docs/es6/typeScript.md
+++ b/docs/es6/typeScript.md
@@ -227,7 +227,7 @@ const result1: intersection = {
 
 ### 联合类型
 
-交叉类型(Union Types)，表示一个值可以是几种类型之一。 我们用竖线 | 分隔每个类型，所以 number | string | boolean表示一个值可以是 number， string，或 boolean
+联合类型(Union Types)，表示一个值可以是几种类型之一。 我们用竖线 | 分隔每个类型，所以 number | string | boolean表示一个值可以是 number， string，或 boolean
 
 ```js
 type arg = string | number | boolean


### PR DESCRIPTION
原文`联合类型`小节中，Union Types 的中文写成了交叉类型。修正了这个笔误。