### PR TITLE
WeakMap的弱引用键的描述容易有歧义。

### DIFF
--- a/docs/es6/dataStructure.md
+++ b/docs/es6/dataStructure.md
@@ -217,7 +217,7 @@ map.forEach((value, key) => { console.log(key, value)})
 
 与`Map`的区别
 - Map 的键可以是任意类型，WeakMap 的键只能是对象类型 
-- WeakMap 键名所指向的对象，不计入垃圾回收机制
+- WeakMap 的键对象，不计入垃圾回收机制
 
 `WeakMap` 的属性跟操作方法与 `Map` 一致，同 `WeakSet` 一样，因为是弱引用，所以 `WeakSet` 也没有遍历方法
 


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakMap 

an object's presence as a `key` in a WeakMap does not prevent the object from being garbage collected. Once an object used as a key has been collected, its corresponding values in any WeakMap become candidates for garbage collection as well