### PR TITLE
修复“es6/#为什么要用proxy重构”示例错误

### DIFF
--- a/docs/es6/index.md
+++ b/docs/es6/index.md
@@ -285,7 +285,6 @@ Object.defineProperty(obj, 'a', {
     console.log(`开始读取属性`)
     return 1; 
   },
-  writable : true
 })
 
 obj.a = 2 // 开始设置新值: 2


### PR DESCRIPTION
对象中存在的属性描述符有两种主要类型：数据描述符和访问器描述符。数据描述符是一个具有可写或不可写值的属性。访问器描述符是由 getter/setter 函数对描述的属性。描述符只能是这两种类型之一，不能同时为两者。